### PR TITLE
Handle empty output and no explicit -out flag

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -36,6 +36,11 @@ module TerraformLandscape
       # Remove preface
       if (match = scrubbed_output.match(/^Path:[^\n]+/))
         scrubbed_output = scrubbed_output[match.end(0)..-1]
+      elsif (match = scrubbed_output.match(/^(~|\+|\-)/))
+        scrubbed_output = scrubbed_output[match.begin(0)..-1]
+      elsif scrubbed_output.match(/^No changes/)
+        @output.puts 'No changes'
+        return
       else
         raise ParseError, 'Output does not contain proper preface'
       end


### PR DESCRIPTION
The tool assumed we were using the `-out` flag to specify an output
file, which would result in `Path: ...` appearing in Terraform's output.

Since we don't want to require the use of the `-out` flag, improve the
preface detection to handle this case. Also handle the case where there
are no changes detected.