### PR TITLE
Cut version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terraform Landscape Change Log
 
-## master (unreleased)
+## 0.1.0
 
 * Don't require `-out` flag on Terraform command
 * Fix handling of Terraform output with no changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Terraform Landscape Change Log
+
+## master (unreleased)
+
+* Don't require `-out` flag on Terraform command
+* Fix handling of Terraform output with no changes
+
+## 0.0.1
+
+* Initial release

--- a/lib/terraform_landscape/version.rb
+++ b/lib/terraform_landscape/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module TerraformLandscape
-  VERSION = '0.0.1'.freeze
+  VERSION = '0.1.0'.freeze
 end


### PR DESCRIPTION
We've fixed a bug that prevented `landscape` from working out of the box when running `terraform plan`. With a fix in place, we're now ready for a "0.1" release.

Also add a change log so we better track changes going forward.