### PR TITLE
Fix windows line endings and cut new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terraform Landscape Change Log
 
-## master (unreleased)
+## 0.1.5
 
 * Fix handling of Windows line endings
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terraform Landscape Change Log
 
+## master (unreleased)
+
+* Fix handling of Windows line endings
+
 ## 0.1.4
 
 * Fix handling of repeated resources with index numbers

--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -27,6 +27,9 @@ class TerraformLandscape::TerraformPlan
 
   class << self
     def from_output(string)
+      # Our grammar assumes output with Unix line endings
+      string = string.gsub("\r\n", "\n")
+
       return new([]) if string.strip.empty?
       tree = parser.parse(string)
       raise ParseError, parser.failure_reason unless tree

--- a/lib/terraform_landscape/version.rb
+++ b/lib/terraform_landscape/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module TerraformLandscape
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -81,6 +81,20 @@ describe TerraformLandscape::TerraformPlan do
       OUT
     end
 
+    context 'when output contains resources separate by Windows newlines' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name\r\n
+        + some_resource_type.some_resource_name\r\n
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+
+        + some_resource_type.some_resource_name
+
+      OUT
+    end
+
     context 'when output contains a single resource with multiple attributes' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         ~ some_resource_type.some_resource_name


### PR DESCRIPTION
Our grammar assumes Unix newlines, so replace Windows newlines before attempting to parse.