### PR TITLE
Printer: add option to ignore postfaces

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -2,8 +2,9 @@ require 'stringio'
 
 module TerraformLandscape
   class Printer
-    def initialize(output)
+    def initialize(output, ignore_postface: false)
       @output = output
+      @ignore_postface = ignore_postface
     end
 
     def process_stream(io)
@@ -46,11 +47,13 @@ module TerraformLandscape
       end
 
       # Remove postface
-      if (match = scrubbed_output.match(/^Plan:[^\n]+/))
-        plan_summary = scrubbed_output[match.begin(0)..match.end(0)]
-        scrubbed_output = scrubbed_output[0...match.begin(0)]
-      else
-        raise ParseError, 'Output does not container proper postface'
+      if !@ignore_postface
+        if (match = scrubbed_output.match(/^Plan:[^\n]+/))
+          plan_summary = scrubbed_output[match.begin(0)..match.end(0)]
+          scrubbed_output = scrubbed_output[0...match.begin(0)]
+        else
+          raise ParseError, 'Output does not container proper postface'
+        end
       end
 
       plan = TerraformPlan.from_output(scrubbed_output)

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -1,0 +1,77 @@
+require_relative './spec_helper'
+require 'terraform_landscape/output'
+require 'terraform_landscape/printer'
+
+describe TerraformLandscape::Printer do
+  describe '#display' do
+    before(:all) do |example|
+      String.disable_colorization = true
+    end
+
+    after(:all) do |example|
+      String.disable_colorization = false
+    end
+
+    subject do
+      @output = StringIO.new
+      output = TerraformLandscape::Output.new(@output)
+      TerraformLandscape::Printer.new(output).process_string(terraform_output)
+      @output.string
+    end
+
+    context 'when there are no changes' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        Acquiring state lock. This may take a few moments...
+        Refreshing Terraform state in-memory prior to plan...
+        The refreshed state will be used to calculate this plan, but will not be
+        persisted to local or remote state storage.
+
+        aws_iam_role.role: Refreshing state... (ID: role)
+        No changes. Infrastructure is up-to-date.
+
+        This means that Terraform did not detect any differences between your
+        configuration and real physical resources that exist. As a result, Terraform
+        doesn't need to do anything.
+        Releasing state lock. This may take a few moments...
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        No changes
+      OUT
+    end
+
+    context 'when output contains a pre- and post-face' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+      Path: terraform.tfplan
+
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:    "3" => "4"
+
+      Plan: 0 to add, 1 to change, 0 to destroy.
+      Releasing state lock. This may take a few moments...
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+      ~ some_resource_type.some_resource_name
+          some_attribute_name:   "3" => "4"
+
+      Plan: 0 to add, 1 to change, 0 to destroy.
+
+      OUT
+    end
+
+    context 'when output does not contain a pre- or post-face' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:    "3" => "4"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:   "3" => "4"
+
+
+      OUT
+    end
+  end
+end


### PR DESCRIPTION
`terraform show` output doesn't contain the postface, and it'd
be nice to be able to landscape over pre-generated plans.