### PR TITLE
Gracefully handle new output format of Terraform 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terraform Landscape Change Log
 
-## master (unreleased)
+## 0.1.9
 
 * Fix handling of additional indentation in Terraform 0.10.0 output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terraform Landscape Change Log
 
+## master (unreleased)
+
+* Fix handling of additional indentation in Terraform 0.10.0 output
+
 ## 0.1.8
 
 * Fix handling of Terraform plan outputs when `-out` flag not specified

--- a/grammar/terraform_plan.treetop
+++ b/grammar/terraform_plan.treetop
@@ -38,7 +38,7 @@ grammar TerraformPlan
   end
 
   rule resource_header
-    change:('~' / '-/+' / '-' / '+' / '<=') _ type:[a-zA-Z0-9_-]+ '.' name:[\S]+ _ '(' reason:[^)]+ ')' {
+    _? change:('~' / '-/+' / '-' / '+' / '<=') _ type:[a-zA-Z0-9_-]+ '.' name:[\S]+ _ '(' reason:[^)]+ ')' {
       def to_ast
         {
           change: change.text_value.to_sym,
@@ -49,7 +49,7 @@ grammar TerraformPlan
       end
     }
     /
-    change:('~' / '-/+' / '-' / '+' / '<=') _ type:[a-zA-Z0-9_-]+ '.' name:[\S]+ {
+    _? change:('~' / '-/+' / '-' / '+' / '<=') _ type:[a-zA-Z0-9_-]+ '.' name:[\S]+ {
       def to_ast
         {
           change: change.text_value.to_sym,

--- a/lib/terraform_landscape/version.rb
+++ b/lib/terraform_landscape/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module TerraformLandscape
-  VERSION = '0.1.8'.freeze
+  VERSION = '0.1.9'.freeze
 end


### PR DESCRIPTION
Terraform 0.10.0 changed the output format to include additional indentation for resource changes. Modify our grammar to support it.