### PR TITLE
Fixed bug in which attribute names cannot have whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terraform Landscape Change Log
 
+## master (unreleased)
+
+* Fix handling of attribute names with spaces
+
 ## 0.1.9
 
 * Fix handling of additional indentation in Terraform 0.10.0 output

--- a/grammar/terraform_plan.treetop
+++ b/grammar/terraform_plan.treetop
@@ -75,7 +75,7 @@ grammar TerraformPlan
   end
 
   rule attribute
-    attribute_name:[^\s:]* ':' _? attribute_value:[^\n]+ {
+    attribute_name:[^:]* ':' _? attribute_value:[^\n]+ {
       def to_ast
         { attribute_name.text_value => attribute_value.text_value }
       end

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -196,7 +196,6 @@ describe TerraformLandscape::TerraformPlan do
     end
 
     context 'when output attribute name contains a space' do
-
       let(:terraform_output) { normalize_indent(<<-TXT) }
         + some_resource_type.some_resource_name
             some_attribute_name:                   "2"

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -195,6 +195,22 @@ describe TerraformLandscape::TerraformPlan do
       OUT
     end
 
+    context 'when output attribute name contains a space' do
+
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name
+            some_attribute_name:                   "2"
+            some_attribute.with space:             "blah"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+            some_attribute_name:         "2"
+            some_attribute.with space:   "blah"
+
+      OUT
+    end
+
     context 'when added resource contains an attribute with JSON' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         + aws_iam_policy.user-my-test


### PR DESCRIPTION
Hi there!

I noticed an issue in which `landscape` assumes that attribute names cannot have spaces in them, where in fact they can. For instance, with `aws_cloudwatch_metric_alarm` [resources](https://www.terraform.io/docs/providers/aws/r/cloudwatch_metric_alarm.html), the `dimension` attribute can have keys that have spaces.

Let me know if this will result in any other issues.

Thanks for putting together this awesome gem!