### PR TITLE
Updates handling for newer `terraform plan` output

### DIFF
--- a/grammar/terraform_plan.treetop
+++ b/grammar/terraform_plan.treetop
@@ -77,20 +77,27 @@ grammar TerraformPlan
   rule attribute
     attribute_name:[^:]* ':' _? attribute_value:[^\n]+ {
       def to_ast
-        { attribute_name.text_value => sanitize_value }
+        { attribute_name.text_value => sanitize_value_and_reason }
       end
 
-      def sanitize_value
+      def sanitize_value_and_reason
         val = attribute_value.text_value
 
         # We'll perform some sanitization of the values within the parser.
 
+        # Handle case where attribute has an annotation (e.g. "forces new resource")
+        if (match = val.match(/\s+\((?<reason>[^)]+)\)$/))
+          reason = match['reason']
+          val = val[0...match.begin(0)]
+        end
+
         # With Terraform >= 0.10.4, the <computed> field is now without quotes,
         # which will cause problem with how downstream we process the output.
         # Convert it to have quotes and handle < 0.10.4 as well.
-        val = val.gsub(%r{<computed>}, '"<computed>"').gsub(%r{""<computed>""}, '"<computed>"')
+        val = val.gsub(%r{=> <computed>$}, '=> "<computed>"')
+                 .gsub(%r{^<computed>}, '"<computed>"')
 
-        val
+        { value: val, reason: reason }
       end
     }
   end

--- a/grammar/terraform_plan.treetop
+++ b/grammar/terraform_plan.treetop
@@ -77,7 +77,20 @@ grammar TerraformPlan
   rule attribute
     attribute_name:[^:]* ':' _? attribute_value:[^\n]+ {
       def to_ast
-        { attribute_name.text_value => attribute_value.text_value }
+        { attribute_name.text_value => sanitize_value }
+      end
+
+      def sanitize_value
+        val = attribute_value.text_value
+
+        # We'll perform some sanitization of the values within the parser.
+
+        # With Terraform >= 0.10.4, the <computed> field is now without quotes,
+        # which will cause problem with how downstream we process the output.
+        # Convert it to have quotes and handle < 0.10.4 as well.
+        val = val.gsub(%r{<computed>}, '"<computed>"').gsub(%r{""<computed>""}, '"<computed>"')
+
+        val
       end
     }
   end

--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -41,6 +41,8 @@ module TerraformLandscape
       # Remove preface
       if (match = scrubbed_output.match(/^Path:[^\n]+/))
         scrubbed_output = scrubbed_output[match.end(0)..-1]
+      elsif (match = scrubbed_output.match(/^Terraform.+following\sactions:/))
+        scrubbed_output = scrubbed_output[match.end(0)..-1]
       elsif (match = scrubbed_output.match(/^\s*(~|\+|\-)/))
         scrubbed_output = scrubbed_output[match.begin(0)..-1]
       elsif scrubbed_output =~ /^No changes/

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -60,6 +60,30 @@ describe TerraformLandscape::Printer do
       OUT
     end
 
+    context 'when output contains a legend of the resource operations' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+      Resource actions are indicated with the following symbols:
+        + create
+        ~ update in-place
+
+      Terraform will perform the following actions:
+
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:    "3" => "4"
+
+      Plan: 0 to add, 1 to change, 0 to destroy.
+      Releasing state lock. This may take a few moments...
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+      ~ some_resource_type.some_resource_name
+          some_attribute_name:   "3" => "4"
+
+      Plan: 0 to add, 1 to change, 0 to destroy.
+
+      OUT
+    end
+
     context 'when output does not contain a Path' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
       Note: You didn't specify an "-out" parameter to save this plan, so when

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -202,6 +202,24 @@ describe TerraformLandscape::TerraformPlan do
       OUT
     end
 
+    context 'when output contains an attribute containing the string <computed>' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        -/+ template_file.demo
+            rendered: "" => "This string contains <computed>"
+            bendered: "" => "This string contains => <computed> with an arrow"
+            template: "" => "This string contains <computed> in it" (forces new resource)
+
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        -/+ template_file.demo
+            rendered:   "" => "This string contains <computed>"
+            bendered:   "" => "This string contains => <computed> with an arrow"
+            template:   "" => "This string contains <computed> in it" (forces new resource)
+
+      OUT
+    end
+
     context 'when output contains multiple modified resources' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         ~ some_resource_type.some_resource_name

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -130,6 +130,24 @@ describe TerraformLandscape::TerraformPlan do
       OUT
     end
 
+    context 'when output contains a rebuilt resource and no quotes' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+          -/+ random_id.abc (tainted)
+              b64:         "e20SLHAH5CXBCw" => <computed>
+              b64_std:     "e20SLHAH5CXBCw==" => <computed>
+              b64_url:     "e20SLHAH5CXBCw" => <computed>
+
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        -/+ random_id.abc (tainted)
+            b64:       "e20SLHAH5CXBCw" => "<computed>"
+            b64_std:   "e20SLHAH5CXBCw==" => "<computed>"
+            b64_url:   "e20SLHAH5CXBCw" => "<computed>"
+
+      OUT
+    end
+
     context 'when output contains a resource read action' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         <= data.external.ext
@@ -157,6 +175,22 @@ describe TerraformLandscape::TerraformPlan do
         -/+ template_file.demo
             rendered: "" => "<computed>"
             template: "" => "<computed>" (forces new resource)
+
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        -/+ template_file.demo
+            rendered:   "" => "<computed>"
+            template:   "" => "<computed>" (forces new resource)
+
+      OUT
+    end
+
+    context 'when output contains an attribute change forcing a rebuild without quotes' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        -/+ template_file.demo
+            rendered: "" => <computed>
+            template: "" => <computed> (forces new resource)
 
       TXT
 
@@ -311,6 +345,21 @@ describe TerraformLandscape::TerraformPlan do
                                "s3:*"
                              ],
                              "Condition": {
+
+      OUT
+    end
+
+    context 'when computed output is included without quotes' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name
+            id:                     <computed>
+            some_attribute_name:    "foo"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+            id:                    "<computed>"
+            some_attribute_name:   "foo"
 
       OUT
     end


### PR DESCRIPTION
With Terraform v0.10.4, the output of `terraform plan` has changed in two ways
which `terraform-landscape` needed updating:

1. The preface to the plan includes a new header which includes a legend to
explain the actions are creating/updating/removing resources.
2. The output of computed fields has changed to no longer be `<computed>` within
quotes.

This addresses the two updates as follows:

1. Updates `Printer` to scrub for the new preface and skip the
legend. Previously, the legend was being processed as a resource, but didn't
match the resource name pattern.
2. Updates the treetop grammar definition to perform some value sanitization, as
this was the easiest place to centrally handle the permutations it might
encounter.

Added numerous tests to account for forwards and backwards compatibility.

Fixes #30 

FYI @colincampbell1967 @NathanTCz