### PR TITLE
Fixes an issue with processing attribute names that include colons.

### DIFF
--- a/grammar/terraform_plan.treetop
+++ b/grammar/terraform_plan.treetop
@@ -75,7 +75,7 @@ grammar TerraformPlan
   end
 
   rule attribute
-    attribute_name:[^:]* ':' _? attribute_value:[^\n]+ {
+    attribute_name:(!': ' .)* ':' _? attribute_value:[^\n]+ {
       def to_ast
         { attribute_name.text_value => sanitize_value_and_reason }
       end

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -381,5 +381,22 @@ describe TerraformLandscape::TerraformPlan do
 
       OUT
     end
+
+    context 'when resouce contains tags and various characters' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name
+            some_attribute_name:   "foo"
+            tags.%:                "1"
+            tags.foo:bar:          "zip:zap"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+            some_attribute_name:   "foo"
+            tags.%:                "1"
+            tags.foo:bar:          "zip:zap"
+
+      OUT
+    end
   end
 end


### PR DESCRIPTION
This fixes an issue with processing resource attribute names that included
colons. This is primarily possible when a tag name includes a colon.

The issue is with the parser grammer only matching an attribute name up until
the colon. It was then failing to evaluate the content since it included extra
data. This changes it to use a lookahead matcher to look for `: `.

Note that this still will be a problem if tag names are using `: `, however I'm
unsure if treetop can do a regex that matches the last occurrance within a line.

FYI @tmatilai 

Fixes #32