### PR TITLE
Handle Terraform show output: `This plan does nothing`

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -45,7 +45,7 @@ module TerraformLandscape
         scrubbed_output = scrubbed_output[match.end(0)..-1]
       elsif (match = scrubbed_output.match(/^\s*(~|\+|\-)/))
         scrubbed_output = scrubbed_output[match.begin(0)..-1]
-      elsif scrubbed_output =~ /^No changes/
+      elsif scrubbed_output =~ /^(No changes|This plan does nothing)/
         @output.puts 'No changes'
         return
       else


### PR DESCRIPTION
Handle `terraform show tf.plan | landscape` 
Terraform Output: 
```
This plan does nothing.
```

https://github.com/hashicorp/terraform/blob/master/command/format/plan.go#L174

We're using terraform show on a generated plan and sending the output through landscape.

The `This plan does nothing` message is the equivalent of the `No changes` message.