### PR TITLE
Scrub dashed lines from Terraform output before parsing

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -36,7 +36,12 @@ module TerraformLandscape
     end
 
     def process_string(plan_output)
-      scrubbed_output = plan_output.gsub(/\e\[\d+m/, '')
+      scrubbed_output = plan_output.gsub(/\e\[\d+m/, '').gsub(/^-{72}\n{2}/, '')
+
+      if scrubbed_output =~ /^(No changes. Infrastructure is up-to-date|This plan does nothing)/
+        @output.puts 'No changes'
+        return
+      end
 
       # Remove preface
       if (match = scrubbed_output.match(/^Path:[^\n]+/))
@@ -45,9 +50,6 @@ module TerraformLandscape
         scrubbed_output = scrubbed_output[match.end(0)..-1]
       elsif (match = scrubbed_output.match(/^\s*(~|\+|\-)/))
         scrubbed_output = scrubbed_output[match.begin(0)..-1]
-      elsif scrubbed_output =~ /^(No changes|This plan does nothing)/
-        @output.puts 'No changes'
-        return
       else
         raise ParseError, 'Output does not contain proper preface'
       end


### PR DESCRIPTION
Resolves issue: #37 

Terraform output can contain dashed lines followed by new lines before output match by regexp.

This scrubs the dashes and new lines before parsing the output and moves the no changes match above the other parsing code.

More details in issue comment: https://github.com/coinbase/terraform-landscape/issues/37#issuecomment-336341627

TF Output before scrubbing:
```
------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.
```

TF Output after scrubbing:
```
No changes. Infrastructure is up-to-date.
```

Probably want to look at updating the test inputs as well.