### PR TITLE
Update the support for unquoted bracketed output.

### DIFF
--- a/grammar/terraform_plan.treetop
+++ b/grammar/terraform_plan.treetop
@@ -103,11 +103,12 @@ grammar TerraformPlan
           val = val[0...match.begin(0)]
         end
 
-        # With Terraform >= 0.10.4, the <computed> field is now without quotes,
-        # which will cause problem with how downstream we process the output.
-        # Convert it to have quotes and handle < 0.10.4 as well.
-        val = val.gsub(%r{=> <computed>$}, '=> "<computed>"')
-                 .gsub(%r{^<computed>}, '"<computed>"')
+        # With Terraform >= 0.10.4, the <computed> and <sensitive> fields are
+        # now without quotes, which will cause problem with how downstream we
+        # process the output.  Convert it to have quotes and handle < 0.10.4 as
+        # well.
+        val = val.gsub(%r{=> <(\w+)>$}, '=> "<\1>"')
+                 .gsub(%r{^<(\w+)>}, '"<\1>"')
 
         { value: val, reason: reason }
       end

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -398,6 +398,36 @@ describe TerraformLandscape::TerraformPlan do
       OUT
     end
 
+    context 'when sensitive output is included without quotes' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name
+            id:                     <sensitive>
+            some_attribute_name:    "foo"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+            id:                    "<sensitive>"
+            some_attribute_name:   "foo"
+
+      OUT
+    end
+
+    context 'when generic bracketed output is included without quotes' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name
+            id:                     <foobar>
+            some_attribute_name:    "foo"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+            id:                    "<foobar>"
+            some_attribute_name:   "foo"
+
+      OUT
+    end
+
     context 'when resouce contains tags and various characters' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         + some_resource_type.some_resource_name


### PR DESCRIPTION
This updates the previous change to handle Terraform outputting `<computed>`
fields without quotes to include other possible values. This was also breaking
for `<sensitive>` fields, such as when launching new RDS instances and defining
the password.

This changes it to just handle generic content so it isn't hardcoded to specific
values.