### PR TITLE
Fix handling of dashed line separators after refresh output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Terraform Landscape Change Log
 
-## master (unreleased)
+## 0.1.17
 
 * Fix handling of dashed line separators after state refresh output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Terraform Landscape Change Log
 
+## master (unreleased)
+
+* Fix handling of dashed line separators after state refresh output
+
 ## 0.1.16
 
 * Fix handling of initialization messages output by `terraform init`

--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -43,6 +43,9 @@ module TerraformLandscape
       # as these break the parser which thinks "-" is a resource deletion
       scrubbed_output.gsub!(/^- .*\.\.\.$/, '')
 
+      # Remove separation lines that appear after refreshing state
+      scrubbed_output.gsub!(/^-+$/, '')
+
       # Remove preface
       if (match = scrubbed_output.match(/^Path:[^\n]+/))
         scrubbed_output = scrubbed_output[match.end(0)..-1]

--- a/lib/terraform_landscape/version.rb
+++ b/lib/terraform_landscape/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module TerraformLandscape
-  VERSION = '0.1.16'.freeze
+  VERSION = '0.1.17'.freeze
 end

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -177,5 +177,34 @@ describe TerraformLandscape::Printer do
         No changes
       OUT
     end
+
+    context 'when output contains a separator after refreshing state' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        Refreshing Terraform state in-memory prior to plan...
+        The refreshed state will be used to calculate this plan, but will not be
+        persisted to local or remote state storage.
+
+        aws_vpc.poc: Refreshing state... (ID:   ##vpc-xxxxxxxxxxxxx)
+        data.aws_iam_policy_document.flowlogs: Refreshing state...
+        data.aws_iam_policy_document.rds_assume_policy: Refreshing state...
+        data.aws_iam_policy_document.flowlogs_assume_role_policy: Refreshing state...
+        aws_iam_role.rds: Refreshing state... (ID: xxxxxxxxxxxxxxxxxRole)
+        aws_iam_role.flowlogs: Refreshing state... (ID: xxxxxxxxxxxxxxRole)
+        aws_iam_role_policy.flowlogs: Refreshing state... (ID: xxxxxxxxxxxxxCreatePolicy)
+        aws_iam_role_policy_attachment.rds: Refreshing state... (ID: xxxxxxxxxxxxxxRole-20171030050803915500000001)
+
+        ------------------------------------------------------------------------
+
+        No changes. Infrastructure is up-to-date.
+
+        This means that Terraform did not detect any differences between your
+        configuration and real physical resources that exist. As a result, no
+        actions need to be performed.
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        No changes
+      OUT
+    end
   end
 end


### PR DESCRIPTION

<!-- The following text is auto-generated from your commit messages -->
### Commit Summary
#### [Fix handling of dashed line separators after refresh output](https://github.com/coinbase/terraform-landscape/commit/7013706b7dccd2e8095d0b5f1805d1270a13eeec)
Fixes #43

---
#### [Cut version 0.1.17](https://github.com/coinbase/terraform-landscape/commit/4bd82b354ad4c212bfd69451d494e198e9032d32)

---
