### PR TITLE
use neatjson to diff json hashes as sorted to get minimized diffs

### DIFF
--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -1,6 +1,6 @@
 require 'colorize'
 require 'diffy'
-require 'json'
+require 'neatjson'
 require 'treetop'
 
 ########################################################################
@@ -111,8 +111,9 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     # Can't JSON.parse an empty string, so handle it separately
     return '' if value.strip.empty?
 
-    JSON.pretty_generate(JSON.parse(value),
+    JSON.neat_generate(JSON.parse(value),
                          {
+                           sort: true,
                            indent: '  ',
                            space: ' ',
                            object_nl: "\n",

--- a/terraform_landscape.gemspec
+++ b/terraform_landscape.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'colorize',    '~> 0.7'
   s.add_dependency 'commander',   '~> 4.4'
   s.add_dependency 'diffy',       '~> 3.0'
+  s.add_dependency 'neatjson',    '~> 0.8'
   s.add_dependency 'treetop',     '~> 1.6'
 end


### PR DESCRIPTION
Sometimes there is json documents in terraform config and sometimes they are sorted at remote side somehow and then diff is hard to read.

I've solved this by using *neatjson* and sort hashes.