### PR TITLE
Sort-of handle `terraform apply`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,25 @@ The best way to see a feature added, however, is to submit a pull request.
 
 * Submit your pull request!
 
+### Development Setup
+
+Install dependencies
+
+```bash
+bundle install
+```
+
+Run tests
+```bash
+bundle exec rspec
+```
+
+Run tests in watch mode
+```bash
+bundle exec guard
+```
+
+
 ## Support Requests
 
 For security reasons, any communication referencing support tickets for Coinbase

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,8 @@ gemspec
 
 gem 'rspec',      '~> 3.0'
 gem 'rubocop',    '0.51.0'
+
+group 'autotest' do
+  gem 'guard-rspec'
+  gem 'ruby_gntp'
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,21 @@
+rspec_options = {
+  cmd: "bundle exec rspec",
+  all_on_start: true
+}
+
+guard :rspec, **rspec_options do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files) { rspec.spec_dir }
+
+  # Ruby files
+  ruby = dsl.ruby
+  watch(ruby.lib_files) { rspec.spec_dir }
+
+  notification :gntp
+end

--- a/lib/terraform_landscape/output.rb
+++ b/lib/terraform_landscape/output.rb
@@ -104,6 +104,13 @@ module TerraformLandscape
       @out.respond_to?(:tty?) && @out.tty?
     end
 
+    # Connect directly to a readable stream
+    def write_from(other_io)
+      while line = other_io.gets do
+        print line
+      end
+    end
+
     private
 
     # Print output in the specified color.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'timeout'
 require 'terraform_landscape'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }


### PR DESCRIPTION
This doesn't try and get too clever with the parser, but it does handle `terraform apply` relatively well.

I think this approach could be extended a bit with some refactoring to pass-through the progress output from terraform commands, and only parse & redisplay the "meat" of the plan itself.

This implements the second strategy mentioned in https://github.com/coinbase/terraform-landscape/issues/53#issuecomment-392192553

I've done some local testing with the binaries on the shell, and the rspec test seems to cover the happy path.