### PR TITLE
'No changes' output with period 'No changes.'

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -59,8 +59,8 @@ module TerraformLandscape
         scrubbed_output = scrubbed_output[match.end(0)..-1]
       elsif (match = scrubbed_output.match(/^\s*(~|\+|\-)/))
         scrubbed_output = scrubbed_output[match.begin(0)..-1]
-      elsif scrubbed_output =~ /^(No changes|This plan does nothing)/
-        @output.puts 'No changes'
+      elsif scrubbed_output =~ /^(No changes\.|This plan does nothing)/
+        @output.puts 'No changes.'
         return
       else
         raise ParseError, 'Output does not contain proper preface'

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -42,7 +42,7 @@ describe TerraformLandscape::Printer do
       TXT
 
       it { should == normalize_indent(<<-OUT) }
-        No changes
+        No changes.
       OUT
     end
 
@@ -63,7 +63,7 @@ describe TerraformLandscape::Printer do
       TXT
 
       it { should == normalize_indent(<<-OUT) }
-        No changes
+        No changes.
       OUT
     end
 
@@ -180,7 +180,7 @@ describe TerraformLandscape::Printer do
       TXT
 
       it { should == normalize_indent(<<-OUT) }
-        No changes
+        No changes.
       OUT
     end
 
@@ -209,7 +209,7 @@ describe TerraformLandscape::Printer do
       TXT
 
       it { should == normalize_indent(<<-OUT) }
-        No changes
+        No changes.
       OUT
     end
   end


### PR DESCRIPTION
I think that output should maintain compatibility when to be used via any other terraform analyze tool.

For example, I use [tfnotify](https://github.com/mercari/tfnotify) that enables to notify terraform diff on GitHub pr.

In our use case, we want to checks without `terraform plan` manually because it is not efficient to do it and comment its result to github.

```
# for example
terraform plan | landscape | tfnotify plan
```

In this pr, I kept the change to minimum.