### PR TITLE
Fix error when buffer contains only part of 3byte UTF-8 characters.

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -29,7 +29,7 @@ module TerraformLandscape
             end
           end
 
-          apply = apply_prompt(buffer.string)
+          apply = apply_prompt(buffer.string.encode('UTF-8', invalid: :replace, replace: ''))
           done = true if apply
         end
         process_string(buffer.string)


### PR DESCRIPTION
Currently landscape read output in unit of 1024bytes. When buffer contains only part of 3-byte UTF-8 character, this causes ArgumentError when matching with regex.

For example, `갱` is 3byte UTF-8 character "\xEA\xB0\xB1" and valid, but "\xEA\xB0" is invalid UTF8 string.

This PR fixes this problem by replacing invalid UTF8 character to empty string.