### PR TITLE
Fix fail parse attribute value

### DIFF
--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -2,6 +2,7 @@ require 'colorize'
 require 'diffy'
 require 'json'
 require 'treetop'
+require 'string_undump'
 
 ########################################################################
 # Represents the parsed output of `terraform plan`.
@@ -175,10 +176,10 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     attribute_value_indent,
     attribute_value_indent_amount
   )
-    # Since the attribute line is always of the form
-    # "old value" => "new value", we can add curly braces and parse with
-    # `eval` to obtain a hash with a single key/value.
-    old, new = eval("{#{attribute_value}}").to_a.first # rubocop:disable Security/Eval
+    # Since the attribute line is always of the form "old value" => "new value"
+    attribute_value =~ /^ *"(.*)" *=> *"(.*)" *$/
+    old = $1.undump
+    new = $2.undump
 
     return if old == new && new != '<sensitive>' # Don't show unchanged attributes
 
@@ -217,7 +218,7 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     @out.print "    #{attribute_name}:".ljust(attribute_value_indent_amount, ' ')
                                        .colorize(change_color)
 
-    evaluated_string = eval(attribute_value) # rubocop:disable Security/Eval
+    evaluated_string = attribute_value.undump
     if json?(evaluated_string)
       @out.print to_pretty_json(evaluated_string).gsub("\n",
                                                        "\n#{attribute_value_indent}")

--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -177,7 +177,7 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     attribute_value_indent_amount
   )
     # Since the attribute line is always of the form "old value" => "new value"
-    attribute_value =~ /^ *"(.*)" *=> *"(.*)" *$/
+    attribute_value =~ /^ *(".*") *=> *(".*") *$/
     old = $1.undump
     new = $2.undump
 

--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -168,7 +168,8 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def display_modified_attribute( # rubocop:disable Metrics/ParameterLists
+  # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+  def display_modified_attribute(
     change_color,
     attribute_name,
     attribute_value,
@@ -178,8 +179,8 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
   )
     # Since the attribute line is always of the form "old value" => "new value"
     attribute_value =~ /^ *(".*") *=> *(".*") *$/
-    old = $1.undump
-    new = $2.undump
+    old = Regexp.last_match[1].undump
+    new = Regexp.last_match[2].undump
 
     return if old == new && new != '<sensitive>' # Don't show unchanged attributes
 

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -456,5 +456,31 @@ describe TerraformLandscape::TerraformPlan do
 
       OUT
     end
+
+    context 'when added resource contains an attribute with ruby string interpolation' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        + some_resource_type.some_resource_name
+            some_attribute_name:    "\#{host}"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        + some_resource_type.some_resource_name
+            some_attribute_name:   "\#{host}"
+
+      OUT
+    end
+
+    context 'when output contains a single resoruce with ruby string interpolation' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:    "\#{host}" => "\#{path}"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:   "\#{host}" => "\#{path}"
+
+      OUT
+    end
   end
 end

--- a/terraform_landscape.gemspec
+++ b/terraform_landscape.gemspec
@@ -22,8 +22,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2'
 
-  s.add_dependency 'colorize',    '~> 0.7'
-  s.add_dependency 'commander',   '~> 4.4'
-  s.add_dependency 'diffy',       '~> 3.0'
-  s.add_dependency 'treetop',     '~> 1.6'
+  s.add_dependency 'colorize',      '~> 0.7'
+  s.add_dependency 'commander',     '~> 4.4'
+  s.add_dependency 'diffy',         '~> 3.0'
+  s.add_dependency 'string_undump', '~> 0.1.1'
+  s.add_dependency 'treetop',       '~> 1.6'
 end


### PR DESCRIPTION

This PR is collection of #73

Circle CI summary: https://circleci.com/gh/dozen/terraform-landscape/8

> Issue: #62
> 
> As you can see from Issue # 62, using eval expands the value like "#{host}".
> 
> So instead of using eval we change it to parse attribute value using regular expression and string_undump.
> 
> Since String # undump is a method introduced from Ruby 2.5, we will make it work with Ruby 2+ by using the string_undump package.