### PR TITLE
Remove initialization messages like "- module.base_network"

### DIFF
--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -1,7 +1,7 @@
 require 'stringio'
 
 module TerraformLandscape
-  # Takes output from Terraform executable nad outputs it in a prettified
+  # Takes output from Terraform executable and outputs it in a prettified
   # format.
   class Printer
     def initialize(output)
@@ -59,8 +59,10 @@ module TerraformLandscape
 
       # Remove initialization messages like
       # "- Downloading plugin for provider "aws" (1.1.0)..."
+      # "- module.base_network"
       # as these break the parser which thinks "-" is a resource deletion
       scrubbed_output.gsub!(/^- .*\.\.\.$/, '')
+      scrubbed_output.gsub!(/^- module\..*$/, '')
 
       # Remove separation lines that appear after refreshing state
       scrubbed_output.gsub!(/^-+$/, '')

--- a/spec/printer_spec.rb
+++ b/spec/printer_spec.rb
@@ -184,6 +184,56 @@ describe TerraformLandscape::Printer do
       OUT
     end
 
+    context 'when output contains module initialization messages' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        Initializing modules...
+        - module.base_network
+          Getting source "../modules/base_network"
+        - module.ecs_service
+          Found version 0.3.0 of ecs-service on registry.terraform.io
+          Getting source "ecs-service"
+
+        Initializing the backend...
+
+        Successfully configured the backend "s3"! Terraform will automatically
+        use this backend unless the backend configuration changes.
+
+        Initializing provider plugins...
+        - Checking for available provider plugins on https://releases.hashicorp.com...
+        - Downloading plugin for provider "aws" (1.1.0)...
+
+        The following providers do not have any version constraints in configuration,
+        so the latest version was installed.
+
+        To prevent automatic upgrades to new major versions that may contain breaking
+        changes, it is recommended to add version = "..." constraints to the
+        corresponding provider blocks in configuration, with the constraint strings
+        suggested below.
+
+        * provider.aws: version = "~> 1.1"
+
+        Terraform has been successfully initialized!
+
+        You may now begin working with Terraform. Try running "terraform plan" to see
+        any changes that are required for your infrastructure. All Terraform commands
+        should now work.
+
+        If you ever set or change modules or backend configuration for Terraform,
+        rerun this command to reinitialize your working directory. If you forget, other
+        commands will detect it and remind you to do so if necessary.
+
+        No changes. Infrastructure is up-to-date.
+
+        This means that Terraform did not detect any differences between your
+        configuration and real physical resources that exist. As a result, no
+        actions need to be performed.
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        No changes.
+      OUT
+    end
+
     context 'when output contains a separator after refreshing state' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         Refreshing Terraform state in-memory prior to plan...


### PR DESCRIPTION
It fixes output like this:
```
Initializing modules...
- module.base_network
  Getting source "../modules/base_network"
- module.ecs_service
  Found version 0.3.0 of ecs-service on registry.terraform.io
  Getting source "ecs-service"
```