### PR TITLE
Support non ASCII attribute

### DIFF
--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -25,8 +25,8 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
 
   DEFAULT_DIFF_CONTEXT_LINES = 5
 
-  UNICODE_ESCAPER = Proc.new { |s|
-    sprintf("\\u%X", s.codepoints[0])
+  UNICODE_ESCAPER = proc { |s|
+    format('\u%X', s.codepoints[0])
   }
 
   class ParseError < StandardError; end
@@ -108,7 +108,7 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
   end
 
   def undump(value)
-    value.encode("ASCII", fallback: UNICODE_ESCAPER).undump
+    value.encode('ASCII', fallback: UNICODE_ESCAPER).undump
   end
 
   def json?(value)

--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -25,7 +25,7 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
   DEFAULT_DIFF_CONTEXT_LINES = 5
 
   UNICODE_ESCAPER = proc { |s|
-    format('\u%X', s.codepoints[0])
+    format('\u%04X', s.codepoints[0])
   }
 
   class ParseError < StandardError; end

--- a/lib/terraform_landscape/terraform_plan.rb
+++ b/lib/terraform_landscape/terraform_plan.rb
@@ -25,6 +25,10 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
 
   DEFAULT_DIFF_CONTEXT_LINES = 5
 
+  UNICODE_ESCAPER = Proc.new { |s|
+    sprintf("\\u%X", s.codepoints[0])
+  }
+
   class ParseError < StandardError; end
 
   class << self
@@ -103,6 +107,10 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     longest_name_length + 8
   end
 
+  def undump(value)
+    value.encode("ASCII", fallback: UNICODE_ESCAPER).undump
+  end
+
   def json?(value)
     ['{', '['].include?(value.to_s[0]) &&
       (JSON.parse(value) rescue nil) # rubocop:disable Style/RescueModifier
@@ -179,8 +187,8 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
   )
     # Since the attribute line is always of the form "old value" => "new value"
     attribute_value =~ /^ *(".*") *=> *(".*") *$/
-    old = Regexp.last_match[1].undump
-    new = Regexp.last_match[2].undump
+    old = undump(Regexp.last_match[1])
+    new = undump(Regexp.last_match[2])
 
     return if old == new && new != '<sensitive>' # Don't show unchanged attributes
 
@@ -219,7 +227,7 @@ class TerraformLandscape::TerraformPlan # rubocop:disable Metrics/ClassLength
     @out.print "    #{attribute_name}:".ljust(attribute_value_indent_amount, ' ')
                                        .colorize(change_color)
 
-    evaluated_string = attribute_value.undump
+    evaluated_string = undump(attribute_value)
     if json?(evaluated_string)
       @out.print to_pretty_json(evaluated_string).gsub("\n",
                                                        "\n#{attribute_value_indent}")

--- a/spec/terraform_plan_spec.rb
+++ b/spec/terraform_plan_spec.rb
@@ -41,6 +41,19 @@ describe TerraformLandscape::TerraformPlan do
       OUT
     end
 
+    context 'when output contains a single resource with one UTF-8 attribute' do
+      let(:terraform_output) { normalize_indent(<<-TXT) }
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:    "3" => "こんにちは"
+      TXT
+
+      it { should == normalize_indent(<<-OUT) }
+        ~ some_resource_type.some_resource_name
+            some_attribute_name:   "3" => "こんにちは"
+
+      OUT
+    end
+
     context 'when output contains a resource with an index number' do
       let(:terraform_output) { normalize_indent(<<-TXT) }
         + some_resource_type.some_resource_name.0


### PR DESCRIPTION
`String#undump` is a function that does the reverse of `String#dump`, so we expect `String#dump` output.

Multibyte characters in `terraform_pran` results are not escaped. They differ from the results of `String#dump` (`String#dump` converts non ASCII characters to Unicode escape sequences).

example:
```ruby
puts 'hello, 世界'.dump              # => "hello, \u4E16\u754C"
puts '"hello, \u4E16\u754C"'.undump # => hello, 世界
puts '"hello, 世界"'
# Traceback (most recent call last):
# 	1: from sample.rb:3:in `<main>'
# sample.rb:3:in `undump': non-ASCII character detected (RuntimeError)
```