### PR TITLE
Fix handling of Windows newlines

### DIFF
--- a/lib/terraform_landscape/cli.rb
+++ b/lib/terraform_landscape/cli.rb
@@ -50,7 +50,7 @@ module TerraformLandscape
 
     def print(options)
       printer = Printer.new(@output)
-      printer.process_stream(STDIN, options)
+      printer.process_stream(ARGF, options)
     end
   end
 end

--- a/lib/terraform_landscape/printer.rb
+++ b/lib/terraform_landscape/printer.rb
@@ -57,6 +57,9 @@ module TerraformLandscape
     def process_string(plan_output) # rubocop:disable Metrics/MethodLength
       scrubbed_output = strip_ansi(plan_output)
 
+      # Our grammar assumes output with Unix line endings
+      scrubbed_output.gsub!("\r\n", "\n")
+
       # Remove initialization messages like
       # "- Downloading plugin for provider "aws" (1.1.0)..."
       # "- module.base_network"


### PR DESCRIPTION
Our preprocessing step was resulting in a bug where we would fail to parse a valid plan. This wasn't caught earlier because the particular confluence of items present in the plan (initialization of modules + no changes) was never exercised.

While here, since it was useful in debugging we added support for specifying an output file via CLI argument.

<!-- The following text is auto-generated from your commit messages -->
### Commit Summary
#### [Allow passing filename as argument to landscape](https://github.com/coinbase/terraform-landscape/commit/59d1c2b041b7b91e6a66fb88eaeb3bad250abf77)
This allows you to pass in a file not via stdin.

---
#### [Convert Windows newlines to Unix newlines](https://github.com/coinbase/terraform-landscape/commit/efa5cbbe76378600c8ed1a481357cca96d57e1a1)
When we preprocess the input, our regex patterns only work with Unix
newlines.

---
